### PR TITLE
Add react-pageflip dependency to fix Netlify build error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tailwindcss/vite": "^4.0.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-pageflip": "^2.0.3",
         "react-router-dom": "^7.1.5",
         "react-typing-effect": "^2.0.5",
         "tailwindcss": "^4.0.6"
@@ -4186,6 +4187,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/page-flip": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/page-flip/-/page-flip-2.0.7.tgz",
+      "integrity": "sha512-96lQFUUz7r/LZzEUZJ3yBIMEKU9+m8HMFDzTvTdD6P7Ag/wXINjp9n0W7b4wanwnDbQETo4uNUoL3zMqpFxwGA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4340,6 +4347,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-pageflip": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-pageflip/-/react-pageflip-2.0.3.tgz",
+      "integrity": "sha512-k81mHhRvUM52y8jyzTCh5t4O0lepkLhp+XGSUzq2C3uD+iW99Cv0jfRlqFCjZbD5N3jKkIFr7/3giucoXKDP3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "page-flip": "latest"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tailwindcss/vite": "^4.0.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-pageflip": "^2.0.3",
     "react-router-dom": "^7.1.5",
     "react-typing-effect": "^2.0.5",
     "tailwindcss": "^4.0.6"


### PR DESCRIPTION
- Install react-pageflip package that was missing from dependencies
- This resolves the dependency resolution issue preventing Netlify deployment
- Book component now has all required dependencies for flipbook functionality